### PR TITLE
Add gunicorn to web server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 FROM python:3.5.1
+
+# System packages
+RUN apt-key update && apt-get update
+#Supervisor for running application in production
+RUN apt-get install supervisor -y
+# Clean up package manager
+RUN apt-get autoremove -y
+RUN rm -rvf /var/cache/apt
+
+# Environment variables
 ENV PYTHONUNBUFFERED 1
+
+# Directories
 RUN mkdir /code
 WORKDIR /code
 ADD . /code/
 RUN pip install -r requirements.txt
+
+# Default entrypoint
+ENTRYPOINT "/code/scripts/run_prod.sh"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Sometimes the postgres image takes a while to load on first run and the Django s
 
 The code in the repository is also mounted as a volume in the task-service container. This means you can edit code on your host machine, using your favorite editor, and the django server will automatically restart to reflect the code changes.
 
-The server should start up at http://localhost:8080/, see the [API docs](https://github.com/cognoma/task-service/blob/master/doc/api.md).
+The server should start up at http://localhost:8001/, see the [API docs](https://github.com/cognoma/task-service/blob/master/doc/api.md).
 
 ## Running tests locally
 

--- a/config/prod/gunicorn.conf
+++ b/config/prod/gunicorn.conf
@@ -1,0 +1,29 @@
+# For full details, see:
+# http://docs.gunicorn.org/en/stable/settings.html
+
+# Address
+bind = '0.0.0.0:8001'
+
+# Worker configuration
+# http://docs.gunicorn.org/en/stable/design.html#async-workers
+worker_class = 'eventlet'
+
+# Rule of thumb for workers is (2 * ncpus) + 1
+# http://docs.gunicorn.org/en/stable/design.html#how-many-workers
+workers = 2
+threads = 8
+worker_connections = 10
+
+# Restart of worker after certain number of requests to avoid memory leaks
+max_requests = 1000
+max_requests_jitter = 100
+
+# Timeout settings
+graceful_timeout = 300
+timeout = 300
+
+# Logging
+loglevel = 'info'
+
+# Daemonization
+daemon = False

--- a/config/prod/supervisord.conf
+++ b/config/prod/supervisord.conf
@@ -1,0 +1,19 @@
+[supervisord]
+; Don't want supervisord to be daemonised, as otherwise when running under
+; Docker it will assume that the command has completed, whereas we want
+; supervisord to stay up as long as the application is running
+nodaemon=true
+
+
+[program:core_service]
+command=/usr/local/bin/gunicorn task_service.wsgi:application -c /code/config/prod/gunicorn.conf
+directory=/code
+; User account with minimal privileges
+user=nobody
+numprocs=1
+autostart=true
+autorestart=true
+; Redirect all logging to Docker stdout
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres
   task:
     build: .
-    command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8001"
+    entrypoint: ./scripts/run_dev.sh
     volumes:
       - .:/code
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pyasn1==0.1.9
 pycparser==2.16
 PyJWT==1.4.2
 six==1.10.0
+gunicorn==19.6.0
+eventlet==0.20.1

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+
+manage.py migrate -v3 --no-input
+python manage.py runserver 0.0.0.0:8001

--- a/scripts/run_prod.sh
+++ b/scripts/run_prod.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+
+# Application is configured to run under Supervisord, which in turn monitors
+# the Gunicorn web server
+supervisord -c /code/config/prod/supervisord.conf


### PR DESCRIPTION
### Motivation

Closes #8 
I only copy the idea of this pr https://github.com/cognoma/core-service/pull/48 here.

### API changes

I don't make any change in API.

### Implementation Notes

Add gunicorn to web server in production.

### Functional Tests

Verify if is possible access API after start a container from docker run.
