### PR TITLE
Fixed static files configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# JetBrains / PyCharm
+.idea/
+
 # C extensions
 *.so
 

--- a/task_service/settings.py
+++ b/task_service/settings.py
@@ -40,6 +40,7 @@ REST_FRAMEWORK = {
 # Application definition
 
 INSTALLED_APPS = [
+    'django.contrib.staticfiles',
     'django.contrib.contenttypes',
     'django.contrib.postgres',
     'rest_framework',
@@ -53,6 +54,8 @@ ROOT_URLCONF = 'task_service.urls'
 
 WSGI_APPLICATION = 'task_service.wsgi.application'
 
+# development
+STATIC_URL = '/static/'
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases

--- a/task_service/urls.py
+++ b/task_service/urls.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.conf.urls import url
+from django.conf.urls.static import static
 from rest_framework.urlpatterns import format_suffix_patterns
 from api import views
 
@@ -11,4 +13,4 @@ urlpatterns = [
     url(r'^tasks/(?P<id>[0-9]+)/touch$', views.TouchTask.as_view()),
     url(r'^tasks/(?P<id>[0-9]+)/release$', views.ReleaseTask.as_view()),
     url(r'^tasks/(?P<id>[0-9]+)/dequeue$', views.DequeueTask.as_view())
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
The browsable API from Django Rest Framework requires Django to be able
to serve static files. This sets up `settings.py` and `urls.py` for serving static files in
development.

Fixes #10